### PR TITLE
FORGE-1876:  @Produces methods returning an API defined in a dependent addon are now considered valid services

### DIFF
--- a/impl/src/main/java/org/jboss/forge/furnace/container/cdi/impl/ContainerServiceExtension.java
+++ b/impl/src/main/java/org/jboss/forge/furnace/container/cdi/impl/ContainerServiceExtension.java
@@ -114,10 +114,9 @@ public class ContainerServiceExtension implements Extension
    public void processProducerHooks(@Observes ProcessProducer<?, ?> event, BeanManager manager)
    {
       Class<?> type = Types.toClass(event.getAnnotatedMember().getJavaMember());
-      ClassLoader classLoader = type.getClassLoader();
-      if (classLoader != null && addon.getClassLoader().equals(classLoader))
+      if (ClassLoaders.containsClass(addon.getClassLoader(), type.getName()))
       {
-         // I am not sure what this is doing anymore.
+         // FORGE-1876: Register @Produces objects as valid services
          services.put(type, manager.createAnnotatedType(type));
       }
    }
@@ -140,7 +139,7 @@ public class ContainerServiceExtension implements Extension
          }
 
          ContextualLifecycle<Object> lifecycle = new ImportedBeanLifecycle(annotated, member, injectionPoint, manager);
-         
+
          Bean<?> serviceBean = new BeanBuilder<>(manager)
                   .beanClass(beanClass)
                   .types(beanTypeClosure)

--- a/tests/src/main/java/test/org/jboss/forge/furnace/mocks/PlainBean.java
+++ b/tests/src/main/java/test/org/jboss/forge/furnace/mocks/PlainBean.java
@@ -13,5 +13,22 @@ package test.org.jboss.forge.furnace.mocks;
  */
 public class PlainBean implements PlainInterface
 {
+   private final String value;
+
+   public PlainBean()
+   {
+      this.value = null;
+   }
+
+   public PlainBean(String value)
+   {
+      this.value = value;
+   }
+
+   @Override
+   public String getValue()
+   {
+      return this.value;
+   }
 
 }

--- a/tests/src/main/java/test/org/jboss/forge/furnace/mocks/PlainInterface.java
+++ b/tests/src/main/java/test/org/jboss/forge/furnace/mocks/PlainInterface.java
@@ -13,5 +13,5 @@ package test.org.jboss.forge.furnace.mocks;
  */
 public interface PlainInterface
 {
-
+   String getValue();
 }

--- a/tests/src/main/java/test/org/jboss/forge/furnace/mocks/QualifiedPlainBean.java
+++ b/tests/src/main/java/test/org/jboss/forge/furnace/mocks/QualifiedPlainBean.java
@@ -14,5 +14,10 @@ package test.org.jboss.forge.furnace.mocks;
 @PlainQualifier
 public class QualifiedPlainBean implements PlainInterface
 {
+   @Override
+   public String getValue()
+   {
+      return null;
+   }
 
 }

--- a/tests/src/main/java/test/org/jboss/forge/furnace/mocks/services/ProducedPlainBean.java
+++ b/tests/src/main/java/test/org/jboss/forge/furnace/mocks/services/ProducedPlainBean.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package test.org.jboss.forge.furnace.mocks.services;
+
+import test.org.jboss.forge.furnace.mocks.PlainInterface;
+
+/**
+ * 
+ * @author <a href="ggastald@redhat.com">George Gastaldi</a>
+ */
+public class ProducedPlainBean implements PlainInterface
+{
+   private String value;
+
+   public ProducedPlainBean(String value)
+   {
+      this.value = value;
+   }
+
+   @Override
+   public String getValue()
+   {
+      return value;
+   }
+
+}

--- a/tests/src/main/java/test/org/jboss/forge/furnace/mocks/services/ProducesPlainInterfaceService.java
+++ b/tests/src/main/java/test/org/jboss/forge/furnace/mocks/services/ProducesPlainInterfaceService.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package test.org.jboss.forge.furnace.mocks.services;
+
+import javax.enterprise.inject.Produces;
+
+import test.org.jboss.forge.furnace.mocks.PlainInterface;
+
+/**
+ * 
+ * @author <a href="ggastald@redhat.com">George Gastaldi</a>
+ */
+public class ProducesPlainInterfaceService
+{
+   @Produces
+   public PlainInterface producePlainInterface()
+   {
+      return new ProducedPlainBean("Produced");
+   }
+}

--- a/tests/src/test/java/test/org/jboss/forge/furnace/services/ProducerTest.java
+++ b/tests/src/test/java/test/org/jboss/forge/furnace/services/ProducerTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2014 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Eclipse Public License version 1.0, available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package test.org.jboss.forge.furnace.services;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.Dependencies;
+import org.jboss.forge.arquillian.archive.ForgeArchive;
+import org.jboss.forge.furnace.addons.AddonRegistry;
+import org.jboss.forge.furnace.repositories.AddonDependencyEntry;
+import org.jboss.forge.furnace.services.Imported;
+import org.jboss.forge.furnace.spi.ServiceRegistry;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import test.org.jboss.forge.furnace.mocks.PlainInterface;
+import test.org.jboss.forge.furnace.mocks.services.ProducedPlainBean;
+import test.org.jboss.forge.furnace.mocks.services.ProducesPlainInterfaceService;
+
+/**
+ * In this test, the interface is in the API addon and the implementation is provided in a JAR (not managed by CDI) in
+ * this addon, which declares a single @Produces for the API interface returning an instance of the implementation in
+ * the JAR
+ * 
+ * @author <a href="ggastald@redhat.com">George Gastaldi</a>
+ */
+@RunWith(Arquillian.class)
+public class ProducerTest
+{
+   @Deployment(order = 1)
+   @Dependencies({
+            @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+   })
+   public static ForgeArchive getDeployment()
+   {
+      JavaArchive implJar = ShrinkWrap.create(JavaArchive.class).addClass(ProducedPlainBean.class);
+
+      ForgeArchive archive = ShrinkWrap
+               .create(ForgeArchive.class)
+               .addBeansXML()
+               .addClasses(ProducesPlainInterfaceService.class)
+               .addAsLibraries(implJar)
+               .addAsAddonDependencies(
+                        AddonDependencyEntry.create("API", "1"),
+                        AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi")
+               );
+      return archive;
+   }
+
+   @Deployment(name = "API,1", testable = false, order = 2)
+   public static ForgeArchive getDeploymentDep1()
+   {
+      ForgeArchive archive = ShrinkWrap
+               .create(ForgeArchive.class)
+               .addBeansXML()
+               .addClass(PlainInterface.class)
+               .addAsAddonDependencies(
+                        AddonDependencyEntry.create("org.jboss.forge.furnace.container:cdi")
+               );
+      return archive;
+   }
+
+   @Inject
+   AddonRegistry addonRegistry;
+
+   @Inject
+   ServiceRegistry serviceRegistry;
+
+   @Test
+   public void testProducer()
+   {
+      Assert.assertTrue(serviceRegistry.hasService(PlainInterface.class));
+      Imported<PlainInterface> services = addonRegistry.getServices(PlainInterface.class);
+      Assert.assertFalse(services.isUnsatisfied());
+      Assert.assertFalse(services.isAmbiguous());
+      PlainInterface pi = services.get();
+      Assert.assertEquals("Produced", pi.getValue());
+   }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/FORGE-1876 for a better explanation
